### PR TITLE
Added PV move ordering

### DIFF
--- a/src/chess/move.hpp
+++ b/src/chess/move.hpp
@@ -12,6 +12,11 @@ struct Move {
     Piece promo;
 };
 
+inline bool operator ==(const Move& lhs, const Move& rhs)
+{
+    return lhs.from == rhs.from && lhs.to == rhs.to && lhs.promo == rhs.promo;
+}
+
 [[maybe_unused]] static void move_str(const Move &move, char *str, const bool flip) {
     static constexpr char promos[] = {'\0', 'n', 'b', 'r', 'q', '\0', '\0'};
 

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -25,7 +25,7 @@ const int material[] = {100, 300, 325, 500, 900};
     return score;
 }
 
-int alphabeta(const chess::Position &pos, int alpha, const int beta, int depth, chess::Move &pv, const int stop_time) {
+int alphabeta(const chess::Position &pos, int alpha, const int beta, int depth, int ply, const int stop_time, chess::Move pvline[]) {
     const int ksq = chess::lsbll(pos.colour[0] & pos.pieces[static_cast<int>(chess::Piece::King)]);
     const auto in_check = chess::attacked(pos, ksq, true);
 
@@ -44,6 +44,15 @@ int alphabeta(const chess::Position &pos, int alpha, const int beta, int depth, 
     int best_move_idx = -1;
 
     for (int i = 0; i < num_moves; ++i) {
+        if(moves[i] == pvline[ply]) {
+            moves[i] = moves[0];
+            moves[0] = pvline[ply];
+            break;
+        }
+    }
+
+    bool raisedAlpha = false;
+    for (int i = 0; i < num_moves; ++i) {
         auto npos = pos;
 
         // Check move legality
@@ -51,7 +60,7 @@ int alphabeta(const chess::Position &pos, int alpha, const int beta, int depth, 
             continue;
         }
 
-        const auto score = -alphabeta(npos, -beta, -alpha, depth - 1, pv, stop_time);
+        const auto score = -alphabeta(npos, -beta, -alpha, depth - 1, ply + 1, stop_time, pvline);
 
         if (score > best_score) {
             best_score = score;
@@ -59,6 +68,7 @@ int alphabeta(const chess::Position &pos, int alpha, const int beta, int depth, 
 
             if (score > alpha) {
                 alpha = score;
+                raisedAlpha = true;
             }
         }
 
@@ -79,8 +89,9 @@ int alphabeta(const chess::Position &pos, int alpha, const int beta, int depth, 
         }
     }
 
-    pv = moves[best_move_idx];
-
+    if(raisedAlpha) {
+        pvline[ply] = moves[best_move_idx];
+    }
     return best_score;
 }
 

--- a/src/engine/search.hpp
+++ b/src/engine/search.hpp
@@ -11,7 +11,7 @@ class Move;
 
 namespace search {
 
-int alphabeta(const chess::Position &pos, int alpha, const int beta, int depth, chess::Move &pv, const int stop_time);
+int alphabeta(const chess::Position &pos, int alpha, const int beta, int depth, int ply, const int stop_time, chess::Move pvline[]);
 
 }  // namespace search
 

--- a/src/engine/uci/go.cpp
+++ b/src/engine/uci/go.cpp
@@ -10,17 +10,16 @@ void go(chess::Position &pos, const int time) {
     char bestmove_str[] = "bestmove 123456";
 
     const auto stop_time = clock() + time / 30'000.0f * CLOCKS_PER_SEC;
-
+    chess::Move pvline[128];
     for (int i = 1; i < 128; ++i) {
-        chess::Move bestmove;
-        search::alphabeta(pos, -INF, INF, i, bestmove, stop_time);
+        search::alphabeta(pos, -INF, INF, i, 0, stop_time, pvline);
 
         // Did we run out of time?
         if (clock() >= stop_time) {
             break;
         }
 
-        chess::move_str(bestmove, &bestmove_str[9], pos.flipped);
+        chess::move_str(pvline[0], &bestmove_str[9], pos.flipped);
     }
 
     puts(bestmove_str);


### PR DESCRIPTION
Score of 4ku vs 4ku-strength-old: 399 - 0 - 1  [0.999] 400
...      4ku playing White: 199 - 0 - 1  [0.998] 200
...      4ku playing Black: 200 - 0 - 0  [1.000] 200
...      White vs Black: 199 - 200 - 1  [0.499] 400
Elo difference: 1161.0 +/- nan, LOS: 100.0 %, DrawRatio: 0.3 %