### PR TITLE
Change to lzma compression

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -29,7 +29,7 @@ strip engine/4ku --strip-all \
       --keep-section=".rodata" \
       --keep-section=".text"
 
-xz ./engine/4ku
-cat ../../launcher.sh ./engine/4ku.xz > ./engine/4ku
-rm ./engine/4ku.xz
+lzma ./engine/4ku
+cat ../../launcher.sh ./engine/4ku.lzma > ./engine/4ku
+rm ./engine/4ku.lzma
 chmod +x ./engine/4ku

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 T=`mktemp`
-tail -c +84 "$0"|xz -d>$T
+tail -c +84 "$0"|lzma -d>$T
 chmod +x $T
 (sleep 3;rm $T)&exec $T


### PR DESCRIPTION
lzma seems to compress better than xz, -46 bytes on my VM.

It might be worth trying `lzma -e`, but that loses 4 bytes on my VM when compressing master. Supposedly the larger the file the more likely -e is to work better, so on strength version it might be worth trying to use -e.