### PR TITLE
LVA and quiescence attempt 2

### DIFF
--- a/src/chess/movegen.cpp
+++ b/src/chess/movegen.cpp
@@ -34,6 +34,7 @@ void generate_piece_moves(Move *movelist,
                           int &num_moves,
                           const Position &pos,
                           const Piece piece,
+                          const bool captures,
                           Bitboard (*func)(int, Bitboard)) {
     auto copy = pos.colour[0] & pos.pieces[static_cast<int>(piece)];
     while (copy) {
@@ -42,6 +43,12 @@ void generate_piece_moves(Move *movelist,
 
         auto moves = func(fr, pos.colour[0] | pos.colour[1]);
         moves &= ~pos.colour[0];
+
+        if (captures) {
+            moves &= pos.colour[1];
+        } else {
+            moves &= ~pos.colour[1];
+        }
 
         while (moves) {
             auto to = lsbll(moves);
@@ -52,39 +59,40 @@ void generate_piece_moves(Move *movelist,
     }
 }
 
-int movegen(const Position &pos, Move *movelist) {
-    int num_moves = 0;
-
+void movegen(const Position &pos, Move *movelist, int &num_moves, const bool captures) {
     const auto all = pos.colour[0] | pos.colour[1];
     const auto empty = ~all;
     const auto pawns = pos.colour[0] & pos.pieces[static_cast<int>(Piece::Pawn)];
 
-    // Pawns
-    generate_pawn_moves(movelist, num_moves, north(pawns) & empty, -8);
-    generate_pawn_moves(movelist, num_moves, north(north(pawns & Bitboard(0xFF00ULL)) & empty) & empty, -16);
-    generate_pawn_moves(movelist, num_moves, nw(pawns) & (pos.colour[1] | pos.ep), -7);
-    generate_pawn_moves(movelist, num_moves, ne(pawns) & (pos.colour[1] | pos.ep), -9);
+    if (captures) {
+        // Pawn captures
+        generate_pawn_moves(movelist, num_moves, nw(pawns) & (pos.colour[1] | pos.ep), -7);
+        generate_pawn_moves(movelist, num_moves, ne(pawns) & (pos.colour[1] | pos.ep), -9);
+    } else {
+        // Pawn quiets
+        generate_pawn_moves(movelist, num_moves, north(pawns) & empty, -8);
+        generate_pawn_moves(movelist, num_moves, north(north(pawns & Bitboard(0xFF00ULL)) & empty) & empty, -16);
+
+        // Castling - King side
+        if (pos.castling[0] && !(all & Bitboard(0x60ULL)) && !attacked(pos, Square::e1, true) &&
+            !attacked(pos, Square::f1, true)) {
+            add_move(movelist, num_moves, Square::e1, Square::g1, Piece::None);
+        }
+
+        // Castling - Queen side
+        if (pos.castling[1] && !(all & Bitboard(0xEULL)) && !attacked(pos, Square::e1, true) &&
+            !attacked(pos, Square::d1, true)) {
+            add_move(movelist, num_moves, Square::e1, Square::c1, Piece::None);
+        }
+    }
+
     // Others
-    generate_piece_moves(movelist, num_moves, pos, Piece::Knight, raycast::knight);
-    generate_piece_moves(movelist, num_moves, pos, Piece::Bishop, raycast::bishop);
-    generate_piece_moves(movelist, num_moves, pos, Piece::Queen, raycast::bishop);
-    generate_piece_moves(movelist, num_moves, pos, Piece::Rook, raycast::rook);
-    generate_piece_moves(movelist, num_moves, pos, Piece::Queen, raycast::rook);
-    generate_piece_moves(movelist, num_moves, pos, Piece::King, raycast::king);
-
-    // Castling - King side
-    if (pos.castling[0] && !(all & Bitboard(0x60ULL)) && !attacked(pos, Square::e1, true) &&
-        !attacked(pos, Square::f1, true)) {
-        add_move(movelist, num_moves, Square::e1, Square::g1, Piece::None);
-    }
-
-    // Castling - Queen side
-    if (pos.castling[1] && !(all & Bitboard(0xEULL)) && !attacked(pos, Square::e1, true) &&
-        !attacked(pos, Square::d1, true)) {
-        add_move(movelist, num_moves, Square::e1, Square::c1, Piece::None);
-    }
-
-    return num_moves;
+    generate_piece_moves(movelist, num_moves, pos, Piece::Knight, captures, raycast::knight);
+    generate_piece_moves(movelist, num_moves, pos, Piece::Bishop, captures, raycast::bishop);
+    generate_piece_moves(movelist, num_moves, pos, Piece::Rook, captures, raycast::rook);
+    generate_piece_moves(movelist, num_moves, pos, Piece::Queen, captures, raycast::bishop);
+    generate_piece_moves(movelist, num_moves, pos, Piece::Queen, captures, raycast::rook);
+    generate_piece_moves(movelist, num_moves, pos, Piece::King, captures, raycast::king);
 }
 
 }  // namespace chess

--- a/src/chess/movegen.hpp
+++ b/src/chess/movegen.hpp
@@ -6,7 +6,7 @@ namespace chess {
 struct Position;
 struct Move;
 
-[[nodiscard]] int movegen(const Position &pos, Move *movelist);
+void movegen(const Position &pos, Move *movelist, int &num_moves, const bool captures);
 
 }  // namespace chess
 

--- a/src/chess/perft.cpp
+++ b/src/chess/perft.cpp
@@ -14,7 +14,9 @@ std::uint64_t perft(const Position &pos, const int depth) {
 
     std::uint64_t nodes = 0;
     Move moves[256];
-    const int num_moves = movegen(pos, moves);
+    int num_moves = 0;
+    chess::movegen(pos, moves, num_moves, true);
+    chess::movegen(pos, moves, num_moves, false);
 
     for (int i = 0; i < num_moves; ++i) {
         auto npos = pos;

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -54,7 +54,7 @@ int alphabeta(const chess::Position &pos,
     chess::Move moves[256];
     int num_moves = 0;
     chess::movegen(pos, moves, num_moves, true);
-    if (depth <= 0) {
+    if (depth > 0) {
         chess::movegen(pos, moves, num_moves, false);
     }
 

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -87,7 +87,7 @@ int alphabeta(const chess::Position &pos,
         }
 
         if (alpha >= beta) {
-            break;
+            return beta;
         }
     }
 
@@ -103,7 +103,7 @@ int alphabeta(const chess::Position &pos,
         }
     }
 
-    return best_score;
+    return alpha;
 }
 
 }  // namespace search

--- a/src/engine/uci/listen.cpp
+++ b/src/engine/uci/listen.cpp
@@ -63,7 +63,10 @@ void listen() {
         }
         // Try parse a move
         else {
-            const int num_moves = chess::movegen(pos, moves);
+            int num_moves = 0;
+            chess::movegen(pos, moves, num_moves, true);
+            chess::movegen(pos, moves, num_moves, false);
+
             for (int i = 0; i < num_moves; ++i) {
                 char movestr[6];
                 chess::move_str(moves[i], movestr, pos.flipped);

--- a/src/tests/chess/moves.cpp
+++ b/src/tests/chess/moves.cpp
@@ -26,7 +26,9 @@ void test(chess::Position &pos, const int depth) {
     }
 
     chess::Move moves[256];
-    const int num_moves = chess::movegen(pos, moves);
+    int num_moves = 0;
+    chess::movegen(pos, moves, num_moves, true);
+    chess::movegen(pos, moves, num_moves, false);
 
     for (int i = 0; i < num_moves; ++i) {
         auto npos = pos;


### PR DESCRIPTION
**Windows:** 
```
Score of 4ku-qsearch2-searchinfo vs 4ku-strength-searchinfo: 195 - 42 - 2  [0.820] 239
...      4ku-qsearch2-searchinfo playing White: 101 - 18 - 2  [0.843] 121
...      4ku-qsearch2-searchinfo playing Black: 94 - 24 - 0  [0.797] 118
...      White vs Black: 125 - 112 - 2  [0.527] 239
Elo difference: 263.5 +/- 58.0, LOS: 100.0 %, DrawRatio: 0.8 %
SPRT: llr 2.21 (100.5%), lbound -2.2, ubound 2.2 - H1 was accepted
```

**Linux:**
```
Score of 4ku-qsearch2-searchinfo vs 4ku-strength-searchinfo: 39 - 6 - 110  [0.606] 155
...      4ku-qsearch2-searchinfo playing White: 19 - 2 - 57  [0.609] 78
...      4ku-qsearch2-searchinfo playing Black: 20 - 4 - 53  [0.604] 77
...      White vs Black: 23 - 22 - 110  [0.503] 155
Elo difference: 75.1 +/- 28.4, LOS: 100.0 %, DrawRatio: 71.0 %
SPRT: llr 2.2 (100.3%), lbound -2.2, ubound 2.2 - H1 was accepted
```

**Size:**
3528 --> 3677
+149