### PR TITLE
Change timing code

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
 
     main.cpp
     search.cpp
+    time.cpp
 
     # Chess
     ../chess/attack.cpp

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -1,4 +1,5 @@
 #include "search.hpp"
+#include "time.hpp"
 #include <chess/attack.hpp>
 #include <chess/bitboard.hpp>
 #include <chess/makemove.hpp>
@@ -30,7 +31,7 @@ int alphabeta(const chess::Position &pos,
               const int beta,
               int depth,
               const int ply,
-              const std::chrono::time_point<std::chrono::steady_clock> stop_time,
+              const long long int stop_time,
               chess::Move *pvline) {
     const int ksq = chess::lsbll(pos.colour[0] & pos.pieces[static_cast<int>(chess::Piece::King)]);
     const auto in_check = chess::attacked(pos, ksq, true);
@@ -40,7 +41,7 @@ int alphabeta(const chess::Position &pos,
     }
 
     // Did we run out of time?
-    if (std::chrono::steady_clock::now() >= stop_time) {
+    if (now() >= stop_time) {
         return 0;
     }
 

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -30,7 +30,7 @@ int alphabeta(const chess::Position &pos,
               const int beta,
               int depth,
               const int ply,
-              const int stop_time,
+              const std::chrono::time_point<std::chrono::steady_clock> stop_time,
               chess::Move *pvline) {
     const int ksq = chess::lsbll(pos.colour[0] & pos.pieces[static_cast<int>(chess::Piece::King)]);
     const auto in_check = chess::attacked(pos, ksq, true);
@@ -40,7 +40,7 @@ int alphabeta(const chess::Position &pos,
     }
 
     // Did we run out of time?
-    if (clock() >= stop_time) {
+    if (std::chrono::steady_clock::now() >= stop_time) {
         return 0;
     }
 

--- a/src/engine/search.hpp
+++ b/src/engine/search.hpp
@@ -1,8 +1,6 @@
 #ifndef SEARCH_HPP
 #define SEARCH_HPP
 
-#include <chrono>
-
 #define MATE_SCORE 10'000'000
 #define INF 20'000'000
 
@@ -18,7 +16,7 @@ int alphabeta(const chess::Position &pos,
               const int beta,
               int depth,
               const int ply,
-              const std::chrono::time_point<std::chrono::steady_clock> stop_time,
+              const long long int stop_time,
               chess::Move *pvline);
 
 }  // namespace search

--- a/src/engine/search.hpp
+++ b/src/engine/search.hpp
@@ -1,6 +1,8 @@
 #ifndef SEARCH_HPP
 #define SEARCH_HPP
 
+#include <chrono>
+
 #define MATE_SCORE 10'000'000
 #define INF 20'000'000
 
@@ -16,7 +18,7 @@ int alphabeta(const chess::Position &pos,
               const int beta,
               int depth,
               const int ply,
-              const int stop_time,
+              const std::chrono::time_point<std::chrono::steady_clock> stop_time,
               chess::Move *pvline);
 
 }  // namespace search

--- a/src/engine/time.cpp
+++ b/src/engine/time.cpp
@@ -1,0 +1,8 @@
+#include "time.hpp"
+#include <ctime>
+
+long long int now() {
+    timespec t;
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return t.tv_sec * 1000 + t.tv_nsec / 1000000;
+}

--- a/src/engine/time.hpp
+++ b/src/engine/time.hpp
@@ -1,0 +1,6 @@
+#ifndef TIME_HPP
+#define TIME_HPP
+
+[[nodiscard]] long long int now();
+
+#endif

--- a/src/engine/uci/go.cpp
+++ b/src/engine/uci/go.cpp
@@ -1,14 +1,14 @@
 #include <stdio.h>
 #include <chess/move.hpp>
 #include <chess/position.hpp>
-#include <chrono>
 #include "../search.hpp"
+#include "../time.hpp"
 #include "listen.hpp"
 
 namespace uci {
 
 void go(chess::Position &pos, const int time) {
-    const auto stop_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(time / 32);
+    const auto stop_time = now() + time / 32;
     char bestmove_str[] = "bestmove 123456";
     chess::Move pvline[128];
 
@@ -17,7 +17,7 @@ void go(chess::Position &pos, const int time) {
         search::alphabeta(pos, -INF, INF, i, 0, stop_time, pvline);
 
         // Did we run out of time?
-        if (std::chrono::steady_clock::now() >= stop_time) {
+        if (now() >= stop_time) {
             break;
         }
 

--- a/src/engine/uci/go.cpp
+++ b/src/engine/uci/go.cpp
@@ -8,7 +8,7 @@
 namespace uci {
 
 void go(chess::Position &pos, const int time) {
-    const auto stop_time = now() + time / 32;
+    const auto stop_time = now() + time / 30;
     char bestmove_str[] = "bestmove 123456";
     chess::Move pvline[128];
 

--- a/src/engine/uci/go.cpp
+++ b/src/engine/uci/go.cpp
@@ -1,13 +1,14 @@
 #include <stdio.h>
 #include <chess/move.hpp>
 #include <chess/position.hpp>
+#include <chrono>
 #include "../search.hpp"
 #include "listen.hpp"
 
 namespace uci {
 
 void go(chess::Position &pos, const int time) {
-    const auto stop_time = clock() + time / 30'000.0f * CLOCKS_PER_SEC;
+    const auto stop_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(time / 32);
     char bestmove_str[] = "bestmove 123456";
     chess::Move pvline[128];
 
@@ -16,7 +17,7 @@ void go(chess::Position &pos, const int time) {
         search::alphabeta(pos, -INF, INF, i, 0, stop_time, pvline);
 
         // Did we run out of time?
-        if (clock() >= stop_time) {
+        if (std::chrono::steady_clock::now() >= stop_time) {
             break;
         }
 


### PR DESCRIPTION
**Linux**
Not sure if it adds elo to the current strength branch, but sure seems to add elo to the qsearch branch? Didn't test fully. We can assume it's 0 elo.

**Windows**
+inf elo. Basically this unbreaks windows builds. It would be very helpful to have this, since it would allow to test further changes ~10 times faster and avoid nonsense like spending hours figuring out what's happening in qsearch testing.

If running really dry on bytes, could revert back to clock(), but while the engine is being worked on it's nice to have.

**Size**
3528 --> 3560
+32