### PR TITLE
Pst

### DIFF
--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -18,12 +18,12 @@ const int material[] = {100, 300, 325, 500, 900, 0};
         for (int p = 0; p < 6; ++p) {
             auto copy = pos.colour[c] & pos.pieces[p];
             while (copy) {
-                const auto fr = chess::lsbll(copy);
+                const auto sq = chess::lsbll(copy);
                 copy &= copy - 1;
 
                 // PST
-                const int rank = fr >> 3;
-                const int file = fr & 7;
+                const int rank = sq >> 3;
+                const int file = sq & 7;
                 const int center_tropism = -std::abs(7 - rank - file) - std::abs(rank - file);
                 score += center_tropism * (6 - p);
 

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -9,7 +9,7 @@
 
 namespace search {
 
-const int material[] = {100, 300, 325, 500, 900};
+const int material[] = {100, 300, 325, 500, 900, 0};
 
 [[nodiscard]] int eval(const chess::Position &pos) {
     int score = 0;

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -15,9 +15,21 @@ const int material[] = {100, 300, 325, 500, 900};
     int score = 0;
 
     for (int c = 0; c < 2; ++c) {
-        // Material
-        for (int p = 0; p < 5; ++p) {
-            score += material[p] * chess::count(pos.pieces[p] & pos.colour[c]);
+        for (int p = 0; p < 6; ++p) {
+            auto copy = pos.colour[c] & pos.pieces[p];
+            while (copy) {
+                const auto fr = chess::lsbll(copy);
+                copy &= copy - 1;
+
+                // PST
+                const int rank = fr >> 3;
+                const int file = fr & 7;
+                const int center_tropism = -std::abs(7 - rank - file) - std::abs(rank - file);
+                score += center_tropism * (6 - p);
+
+                // Material
+                score += material[p];
+            }
         }
 
         score = -score;


### PR DESCRIPTION
```
Score of 4ku-pst vs 4ku-strength: 635 - 514 - 1097  [0.527] 2246
...      4ku-pst playing White: 297 - 260 - 566  [0.516] 1123
...      4ku-pst playing Black: 338 - 254 - 531  [0.537] 1123
...      White vs Black: 551 - 598 - 1097  [0.490] 2246
Elo difference: 18.7 +/- 10.3, LOS: 100.0 %, DrawRatio: 48.8 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```

**Size**
3560 --> 3558
-2