### PR TITLE
Strength improvements

### DIFF
--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -50,6 +50,8 @@ const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
                         score += passers[rank];
                     }
                 } else if (p == static_cast<int>(chess::Piece::Rook)) {
+
+                    // Open and semi-open files
                     const auto file_bb = 0x101010101010101ULL << file;
                     if ((file_bb & pawns[0]) == 0) {
                         if ((file_bb & pawns[1]) == 0) {
@@ -57,6 +59,8 @@ const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
                         }
                         score += 5;
                     }
+
+                    // Bonus on 7th/8th rank
                     if (rank >= 6) {
                         score += 15;
                     }
@@ -100,6 +104,8 @@ int alphabeta(chess::Position &pos,
             alpha = static_eval;
         }
     } else if (depth < 3) {
+
+        // Reverse futility pruning
         const int margin = 120;
         if (static_eval - margin * depth >= beta) {
             return beta;
@@ -133,6 +139,8 @@ int alphabeta(chess::Position &pos,
 
     int best_score = -INF;
     for (int i = 0; i < num_moves; ++i) {
+
+        // Pick next move
         int best_move_score = 0;
         int best_move_score_index = i;
         for (int j = i; j < num_moves; ++j) {
@@ -162,6 +170,7 @@ int alphabeta(chess::Position &pos,
             continue;
         }
 
+        // Poor man's PVS
         const int new_beta = -alpha;
         int new_alpha = -alpha - 1;
         goto do_search;

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -19,7 +19,10 @@ const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
     int score = 10;
 
     for (int c = 0; c < 2; ++c) {
-        const auto opp_pawns = pos.colour[1] & pos.pieces[static_cast<int>(chess::Piece::Pawn)];
+        chess::Bitboard pawns[2];
+        for (int c2 = 0; c2 < 2; ++c2) {
+            pawns[c2] = pos.colour[c2] & pos.pieces[static_cast<int>(chess::Piece::Pawn)];
+        }
 
         for (int p = 0; p < 6; ++p) {
             auto copy = pos.colour[0] & pos.pieces[p];
@@ -42,9 +45,20 @@ const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
                     for (auto i = 0; i < 4; ++i) {
                         attack |= chess::north(attack);
                     }
-                    const auto is_passed = (attack & opp_pawns) == 0;
+                    const auto is_passed = (attack & pawns[1]) == 0;
                     if (is_passed) {
                         score += passers[rank];
+                    }
+                } else if (p == static_cast<int>(chess::Piece::Rook)) {
+                    const auto file_bb = 0x101010101010101ULL << file;
+                    if ((file_bb & pawns[0]) == 0) {
+                        if ((file_bb & pawns[1]) == 0) {
+                            score += 5;
+                        }
+                        score += 5;
+                    }
+                    if (rank >= 6) {
+                        score += 15;
                     }
                 }
 

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -13,16 +13,16 @@ namespace search {
 const int material[] = {100, 300, 325, 500, 900, 0};
 const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
 
-[[nodiscard]] int eval(const chess::Position &pos) {
+[[nodiscard]] int eval(chess::Position &pos) {
 
     // Tempo bonus
     int score = 10;
 
     for (int c = 0; c < 2; ++c) {
-        const auto opp_pawns = pos.colour[c ^ 1] & pos.pieces[static_cast<int>(chess::Piece::Pawn)];
+        const auto opp_pawns = pos.colour[1] & pos.pieces[static_cast<int>(chess::Piece::Pawn)];
 
         for (int p = 0; p < 6; ++p) {
-            auto copy = pos.colour[c] & pos.pieces[p];
+            auto copy = pos.colour[0] & pos.pieces[p];
             while (copy) {
                 const auto sq = chess::lsbll(copy);
                 copy &= copy - 1;
@@ -38,14 +38,13 @@ const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
                     const auto bb = 1ULL << sq;
 
                     // Passed pawns
-                    auto attack = c == 0 ? chess::nw(bb) | chess::ne(bb) : chess::sw(bb) | chess::se(bb);
+                    auto attack = chess::nw(bb) | chess::ne(bb);
                     for (auto i = 0; i < 4; ++i) {
-                        attack |= c == 0 ? chess::north(attack) : chess::south(attack);
+                        attack |= chess::north(attack);
                     }
                     const auto is_passed = (attack & opp_pawns) == 0;
                     if (is_passed) {
-                        const auto rel_rank = c == 0 ? rank : 7 - rank;
-                        score += passers[rel_rank];
+                        score += passers[rank];
                     }
                 }
 
@@ -54,13 +53,14 @@ const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
             }
         }
 
+        chess::flip(pos);
         score = -score;
     }
 
     return score;
 }
 
-int alphabeta(const chess::Position &pos,
+int alphabeta(chess::Position &pos,
               int alpha,
               const int beta,
               int depth,

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -75,15 +75,20 @@ int alphabeta(chess::Position &pos,
         depth++;
     }
 
+    const int static_eval = eval(pos);
     const bool in_qsearch = depth <= 0;
     if (in_qsearch) {
-        const int static_eval = eval(pos);
         if (static_eval >= beta) {
             return beta;
         }
 
         if (alpha < static_eval) {
             alpha = static_eval;
+        }
+    } else if (depth < 3) {
+        const int margin = 120;
+        if (static_eval - margin * depth >= beta) {
+            return beta;
         }
     }
 

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -14,7 +14,6 @@ const int material[] = {100, 300, 325, 500, 900, 0};
 const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
 
 [[nodiscard]] int eval(chess::Position &pos) {
-
     // Tempo bonus
     int score = 10;
 
@@ -50,7 +49,6 @@ const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
                         score += passers[rank];
                     }
                 } else if (p == static_cast<int>(chess::Piece::Rook)) {
-
                     // Open and semi-open files
                     const auto file_bb = 0x101010101010101ULL << file;
                     if ((file_bb & pawns[0]) == 0) {
@@ -104,7 +102,6 @@ int alphabeta(chess::Position &pos,
             alpha = static_eval;
         }
     } else if (depth < 3) {
-
         // Reverse futility pruning
         const int margin = 120;
         if (static_eval - margin * depth >= beta) {
@@ -131,7 +128,8 @@ int alphabeta(chess::Position &pos,
             // MVVLVA
             const auto capture = chess::piece_on(pos, moves[j].to);
             if (capture != chess::Piece::None) {
-                move_score = ((static_cast<int>(capture) + 1) * 8) - static_cast<int>(chess::piece_on(pos, moves[j].from));
+                move_score =
+                    ((static_cast<int>(capture) + 1) * 8) - static_cast<int>(chess::piece_on(pos, moves[j].from));
             }
         }
         move_scores[j] = move_score;
@@ -139,7 +137,6 @@ int alphabeta(chess::Position &pos,
 
     int best_score = -INF;
     for (int i = 0; i < num_moves; ++i) {
-
         // Pick next move
         int best_move_score = 0;
         int best_move_score_index = i;
@@ -174,9 +171,9 @@ int alphabeta(chess::Position &pos,
         const int new_beta = -alpha;
         int new_alpha = -alpha - 1;
         goto do_search;
-        full_search:
+    full_search:
         new_alpha = -beta;
-        do_search:
+    do_search:
         const int score = -alphabeta(npos, new_alpha, new_beta, depth - 1, ply + 1, stop_time, pvline);
         if (score > alpha && new_alpha != -beta) {
             goto full_search;

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -151,9 +151,7 @@ int alphabeta(chess::Position &pos,
         moves[i] = moves[best_move_score_index];
         moves[best_move_score_index] = temp_move;
 
-        const auto temp_move_score = move_scores[i];
-        move_scores[i] = move_scores[best_move_score_index];
-        move_scores[best_move_score_index] = temp_move_score;
+        move_scores[best_move_score_index] = move_scores[i];
 
         // Since moves are ordered captures first, break in qsearch
         if (in_qsearch && chess::piece_on(pos, moves[i].to) == chess::Piece::None) {

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -14,7 +14,9 @@ const int material[] = {100, 300, 325, 500, 900, 0};
 const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
 
 [[nodiscard]] int eval(const chess::Position &pos) {
-    int score = 0;
+
+    // Tempo bonus
+    int score = 10;
 
     for (int c = 0; c < 2; ++c) {
         const auto opp_pawns = pos.colour[c ^ 1] & pos.pieces[static_cast<int>(chess::Piece::Pawn)];

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -147,13 +147,13 @@ int alphabeta(chess::Position &pos,
             }
         }
 
-        const auto tempMove = moves[i];
+        const auto temp_move = moves[i];
         moves[i] = moves[best_move_score_index];
-        moves[best_move_score_index] = tempMove;
+        moves[best_move_score_index] = temp_move;
 
-        const auto tempMoveScore = move_scores[i];
+        const auto temp_move_score = move_scores[i];
         move_scores[i] = move_scores[best_move_score_index];
-        move_scores[best_move_score_index] = tempMoveScore;
+        move_scores[best_move_score_index] = temp_move_score;
 
         // Since moves are ordered captures first, break in qsearch
         if (in_qsearch && chess::piece_on(pos, moves[i].to) == chess::Piece::None) {

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -148,7 +148,16 @@ int alphabeta(chess::Position &pos,
             continue;
         }
 
-        const auto score = -alphabeta(npos, -beta, -alpha, depth - 1, ply + 1, stop_time, pvline);
+        const int new_beta = -alpha;
+        int new_alpha = -alpha - 1;
+        goto do_search;
+        full_search:
+        new_alpha = -beta;
+        do_search:
+        const int score = -alphabeta(npos, new_alpha, new_beta, depth - 1, ply + 1, stop_time, pvline);
+        if (score > alpha && new_alpha != -beta) {
+            goto full_search;
+        }
 
         if (score > best_score) {
             best_score = score;

--- a/src/engine/search.hpp
+++ b/src/engine/search.hpp
@@ -1,8 +1,8 @@
 #ifndef SEARCH_HPP
 #define SEARCH_HPP
 
-#define MATE_SCORE 10'000'000
-#define INF 20'000'000
+#define MATE_SCORE (1 << 15)
+#define INF (1 << 16)
 
 namespace chess {
 class Position;

--- a/src/engine/search.hpp
+++ b/src/engine/search.hpp
@@ -11,7 +11,7 @@ class Move;
 
 namespace search {
 
-int alphabeta(const chess::Position &pos,
+int alphabeta(chess::Position &pos,
               int alpha,
               const int beta,
               int depth,

--- a/src/engine/uci/go.cpp
+++ b/src/engine/uci/go.cpp
@@ -9,7 +9,7 @@ namespace uci {
 
 void go(chess::Position &pos, const int time) {
     const auto stop_time = now() + time / 30;
-    char bestmove_str[] = "bestmove 123456";
+    char bestmove_str[] = "bestmove       ";
     chess::Move pvline[128];
 
     // Iterative deepening


### PR DESCRIPTION
Improve move ordering, passed pawns
Add tempo, reverse futility, sort of a version of PVS, open file detection

```
Score of 4ku-test.exe vs 4ku-strength-1: 405 - 138 - 457  [0.633] 1000
...      4ku-test.exe playing White: 203 - 78 - 220  [0.625] 501
...      4ku-test.exe playing Black: 202 - 60 - 237  [0.642] 499
...      White vs Black: 263 - 280 - 457  [0.491] 1000
Elo difference: 95.1 +/- 15.9, LOS: 100.0 %, DrawRatio: 45.7 %
```

**Size**
3858 --> 3888
+30 bytes