### PR TITLE
Printing basic search info, texel tuned values

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -16,6 +16,11 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
+option(USE_SEARCHINFO "Produce UCI 'info' output" OFF)
+if(USE_SEARCHINFO)
+    add_definitions(-DUSE_SEARCHINFO)
+endif()
+
 # Add engine executable
 add_executable(
     4ku

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -10,8 +10,9 @@
 
 namespace search {
 
-const int material[] = {100, 300, 325, 500, 900, 0};
-const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
+const int material[] = {87, 332, 363, 534, 1076, 0};
+const int centralities[] = {7, 20, 18, 1, 2, 2};
+const int passers[] = {21, 14, 9, 24, 76, 171};
 
 #ifdef USE_SEARCHINFO
 unsigned long long int nodes_searched;
@@ -33,11 +34,12 @@ unsigned long long int nodes_searched;
                 const auto sq = chess::lsbll(copy);
                 copy &= copy - 1;
 
-                // Centrality
                 const int rank = sq >> 3;
                 const int file = sq & 7;
-                const int centrality = -std::abs(7 - rank - file) - std::abs(rank - file);
-                score += centrality * (6 - p);
+
+                // Centrality
+                const int centrality = (7 - std::abs(7 - rank - file) - std::abs(rank - file)) / 2;
+                score += centrality * centralities[p];
 
                 // Pawn eval
                 if (p == static_cast<int>(chess::Piece::Pawn)) {
@@ -50,21 +52,22 @@ unsigned long long int nodes_searched;
                     }
                     const auto is_passed = (attack & pawns[1]) == 0;
                     if (is_passed) {
-                        score += passers[rank];
+                        score += passers[rank - 1];
                     }
                 } else if (p == static_cast<int>(chess::Piece::Rook)) {
                     // Open and semi-open files
                     const auto file_bb = 0x101010101010101ULL << file;
                     if ((file_bb & pawns[0]) == 0) {
                         if ((file_bb & pawns[1]) == 0) {
-                            score += 5;
+                            score += 43;
+                        } else {
+                            score += 26;
                         }
-                        score += 5;
                     }
 
                     // Bonus on 7th/8th rank
                     if (rank >= 6) {
-                        score += 15;
+                        score += 26;
                     }
                 }
 

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -10,9 +10,12 @@
 
 namespace search {
 
-const int material[] = {87, 332, 363, 534, 1076, 0};
-const int centralities[] = {7, 20, 18, 1, 2, 2};
-const int passers[] = {21, 14, 9, 24, 76, 171};
+constexpr int material[] = {100, 339, 372, 582, 1180};
+constexpr int centralities[] = {2, 20, 16, 1, 3, 11};
+constexpr int passers[] = {17, 11, 13, 31, 93, 192};
+constexpr int rook_semi_open = 25;
+constexpr int rook_open = 35;
+constexpr int rook_rank78 = 24;
 
 #ifdef USE_SEARCHINFO
 unsigned long long int nodes_searched;
@@ -59,15 +62,15 @@ unsigned long long int nodes_searched;
                     const auto file_bb = 0x101010101010101ULL << file;
                     if ((file_bb & pawns[0]) == 0) {
                         if ((file_bb & pawns[1]) == 0) {
-                            score += 43;
+                            score += rook_open;
                         } else {
-                            score += 26;
+                            score += rook_semi_open;
                         }
                     }
 
                     // Bonus on 7th/8th rank
                     if (rank >= 6) {
-                        score += 26;
+                        score += rook_rank78;
                     }
                 }
 
@@ -171,7 +174,7 @@ int alphabeta(chess::Position &pos,
         }
 
 #ifdef USE_SEARCHINFO
-        ++nodes_searched;
+        nodes_searched++;
 #endif
 
         // Poor man's PVS

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -13,6 +13,10 @@ namespace search {
 const int material[] = {100, 300, 325, 500, 900, 0};
 const int passers[] = {0, 20, 20, 32, 56, 92, 140, 0};
 
+#ifdef USE_SEARCHINFO
+unsigned long long int nodes_searched;
+#endif
+
 [[nodiscard]] int eval(chess::Position &pos) {
     // Tempo bonus
     int score = 10;
@@ -162,6 +166,10 @@ int alphabeta(chess::Position &pos,
         if (!chess::makemove(npos, move)) {
             continue;
         }
+
+#ifdef USE_SEARCHINFO
+        ++nodes_searched;
+#endif
 
         // Poor man's PVS
         const int new_beta = -alpha;

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -147,21 +147,19 @@ int alphabeta(chess::Position &pos,
             }
         }
 
-        const auto temp_move = moves[i];
-        moves[i] = moves[best_move_score_index];
-        moves[best_move_score_index] = temp_move;
-
+        const auto move = moves[best_move_score_index];
+        moves[best_move_score_index] = moves[i];
         move_scores[best_move_score_index] = move_scores[i];
 
         // Since moves are ordered captures first, break in qsearch
-        if (in_qsearch && chess::piece_on(pos, moves[i].to) == chess::Piece::None) {
+        if (in_qsearch && chess::piece_on(pos, move.to) == chess::Piece::None) {
             break;
         }
 
         auto npos = pos;
 
         // Check move legality
-        if (!chess::makemove(npos, moves[i])) {
+        if (!chess::makemove(npos, move)) {
             continue;
         }
 
@@ -182,7 +180,7 @@ int alphabeta(chess::Position &pos,
 
             if (score > alpha) {
                 alpha = score;
-                pvline[ply] = moves[i];
+                pvline[ply] = move;
             }
         }
 

--- a/src/engine/search.hpp
+++ b/src/engine/search.hpp
@@ -11,6 +11,11 @@ class Move;
 
 namespace search {
 
+#define USE_SEARCHINFO
+#ifdef USE_SEARCHINFO
+extern unsigned long long nodes_searched;
+#endif
+
 int alphabeta(chess::Position &pos,
               int alpha,
               const int beta,

--- a/src/engine/search.hpp
+++ b/src/engine/search.hpp
@@ -11,9 +11,8 @@ class Move;
 
 namespace search {
 
-#define USE_SEARCHINFO
 #ifdef USE_SEARCHINFO
-extern unsigned long long nodes_searched;
+extern unsigned long long int nodes_searched;
 #endif
 
 int alphabeta(chess::Position &pos,

--- a/src/engine/uci/go.cpp
+++ b/src/engine/uci/go.cpp
@@ -11,10 +11,17 @@ void go(chess::Position &pos, const int time) {
     const auto stop_time = now() + time / 30;
     char bestmove_str[] = "bestmove       ";
     chess::Move pvline[128];
-
+#ifdef USE_SEARCHINFO
+    search::nodes_searched = 0;
+    const auto start_time = now();
+#endif
     // Iterative deepening
     for (int i = 1; i < 128; ++i) {
+#ifdef USE_SEARCHINFO
+        const auto score = search::alphabeta(pos, -INF, INF, i, 0, stop_time, pvline);
+#else
         search::alphabeta(pos, -INF, INF, i, 0, stop_time, pvline);
+#endif
 
         // Did we run out of time?
         if (now() >= stop_time) {
@@ -22,6 +29,14 @@ void go(chess::Position &pos, const int time) {
         }
 
         chess::move_str(pvline[0], &bestmove_str[9], pos.flipped);
+#ifdef USE_SEARCHINFO
+        auto elapsed = now() - start_time;
+        if (elapsed == 0) {
+            elapsed = 1;
+        }
+        const auto nps = search::nodes_searched * 1000 / elapsed;
+        std::printf("info depth %i score %i nodes %lld nps %lld time %lld\n", i, score, search::nodes_searched, nps, elapsed);
+#endif
     }
 
     puts(bestmove_str);


### PR DESCRIPTION
```
Score of 4ku-test.exe vs 4ku-strength-1: 203 - 121 - 306  [0.565] 630
...      4ku-test.exe playing White: 111 - 53 - 152  [0.592] 316
...      4ku-test.exe playing Black: 92 - 68 - 154  [0.538] 314
...      White vs Black: 179 - 145 - 306  [0.527] 630
Elo difference: 45.5 +/- 19.5, LOS: 100.0 %, DrawRatio: 48.6 %
SPRT: llr 2.22 (100.9%), lbound -2.2, ubound 2.2 - H1 was accepted
```

**Size:**
3888 --> 3888
0 bytes